### PR TITLE
I've updated PyTorch and Torchvision to ensure compatibility with python3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version-specific requirements to avoid compatibility issues
 streamlit==1.32.0
-torch==2.2.0
-torchvision==0.17.0
+torch==2.5.0
+torchvision==0.18.0
 numpy==1.24.3
 pandas==2.0.3
 Pillow==10.0.0


### PR DESCRIPTION

Specifically, I updated `torch` to version 2.5.0 and `torchvision` to version 0.18.0 in your `requirements.txt` file. This change addresses a dependency resolution error that was occurring in the Streamlit Cloud environment (using Python 3.13.3) because appropriate wheels for `torch` 2.2.0 were not available.