### PR TITLE
I've updated PyTorch and Torchvision to versions compatible with Pyth…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version-specific requirements to avoid compatibility issues
 streamlit==1.32.0
-torch==2.5.0
-torchvision==0.18.0
+torch==2.7.0
+torchvision==0.22.0
 numpy==1.24.3
 pandas==2.0.3
 Pillow==10.0.0


### PR DESCRIPTION
…on 3.13.

Specifically, I updated `torch` to `2.7.0` and `torchvision` to `0.22.0` in your `requirements.txt` file. This change is based on feedback from Streamlit Cloud deployment logs, which indicated these versions are available for the Python 3.13.3 environment you're using.