### PR TITLE
I've updated NumPy to version 1.26.4 in your `requirements.txt` file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 streamlit==1.32.0
 torch==2.7.0
 torchvision==0.22.0
-numpy==1.24.3
+numpy==1.26.4
 pandas==2.0.3
 Pillow==10.0.0
 ultralytics==8.1.0


### PR DESCRIPTION
This change from version 1.24.3 to 1.26.4 addresses a build failure you were experiencing with Python 3.13.3. The issue stemmed from the removal of 'distutils', which the older NumPy version's build process depended on.