### PR TITLE
Update Pillow and Pandas for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ streamlit==1.32.0
 torch==2.7.0
 torchvision==0.22.0
 numpy==1.26.4
-pandas==2.0.3
-Pillow==10.0.0
+pandas==2.2.2
+Pillow==10.4.0
 ultralytics==8.1.0


### PR DESCRIPTION
Changed Pillow to 10.4.0 and pandas to 2.2.2 in requirements.txt. This addresses build failures you encountered with older versions of these packages on Python 3.13.3, specifically a KeyError for Pillow and to proactively update pandas.